### PR TITLE
Add multiselection parameter to dropdown options

### DIFF
--- a/NarrativeMethodStore.spec
+++ b/NarrativeMethodStore.spec
@@ -182,6 +182,23 @@ module NarrativeMethodStore {
         string display;
     } DropdownOption;
 
+
+    /*
+     Defines a parameter field that allows users to select from a list of options. It will
+     appear as a dropdown (a 'select' HTML element).
+
+     Parameters:
+
+        options   - a list of maps with keys 'value' and 'display'; 'display' is the text
+                  presented to the user, and 'value' is what is passed from the element
+                  when it is submitted. See the DropDownOption type for the spec.
+
+        multiselection - If true, multiple selections are allowed from a single field, and
+                  the parameter will return a list, rather than a single value.
+                  This parameter is optional.
+                  Default = false
+     */
+
     typedef structure {
         list<DropdownOption> options;
         boolean multiselection;

--- a/NarrativeMethodStore.spec
+++ b/NarrativeMethodStore.spec
@@ -184,6 +184,7 @@ module NarrativeMethodStore {
 
     typedef structure {
         list<DropdownOption> options;
+        boolean multiselection;
     } DropdownOptions;
 
     typedef structure {
@@ -299,16 +300,16 @@ module NarrativeMethodStore {
 
             result_array_index - The index of the result array returned from the dynamic service
                            from where the selection items will be extracted. Default 0.
-                           
+
             path_to_selection_items - The path into the result data object to the list of
                            selection items. If missing, the data at the specified result array
                            index is used (defaulting to the first returned value in the list).
-                           
+
             The selection items data structure must be a list of mappings or structures.
-            
+
             As an example of correctly specifying where the selection items are within the
             data structure returned from the dynamic service, if the data structure is:
-            
+
             [
                 "foo",                # return array position 0
                 {                     # return array position 1
@@ -330,15 +331,15 @@ module NarrativeMethodStore {
                  },
                  "bar"                # return array position 2
              ]
-             
+
             Note that KBase dynamic services all return an array of values, even for single-value
             returns, as the KIDL spec allows specifying multiple return values per function.
-            
+
             In this case:
                 result_array_index would be 1
                 path_to_selection_items would be ["interesting_data", "2"]
                 selection_id would be "name"
-                
+
             The selection items would be the 42 items represented by
             {"id": 1,
              "name": "foo"
@@ -347,12 +348,12 @@ module NarrativeMethodStore {
             {"id": 42,
              "name": "wowbagger"
              }
-            
+
             Selection items must always be a list of maps.
-            
+
             The final value returned when the user selects a value would be the "name" field -
             "foo" if the first item is selected, and "wowbagger" if the last item is selected.
-                 
+
     */
 
     typedef structure {

--- a/src/us/kbase/narrativemethodstore/DropdownOptions.java
+++ b/src/us/kbase/narrativemethodstore/DropdownOptions.java
@@ -14,19 +14,37 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * <p>Original spec-file type: DropdownOptions</p>
- * 
- * 
+ *
+ *
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
+    "multiselection",
     "options"
 })
 public class DropdownOptions {
 
+    @JsonProperty("multiselection")
+    private Long multiselection;
     @JsonProperty("options")
     private List<DropdownOption> options;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("multiselection")
+    public Long getMultiselection() {
+        return multiselection;
+    }
+
+    @JsonProperty("multiselection")
+    public void setMultiselection(Long multiselection) {
+        this.multiselection = multiselection;
+    }
+
+    public DropdownOptions withMultiselection(Long multiselection) {
+        this.multiselection = multiselection;
+        return this;
+    }
 
     @JsonProperty("options")
     public List<DropdownOption> getOptions() {
@@ -55,7 +73,7 @@ public class DropdownOptions {
 
     @Override
     public String toString() {
-        return ((((("DropdownOptions"+" [options=")+ options)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((("DropdownOptions"+" [options=")+ options)+", multiselection=")+ multiselection)+
+", additionalProperties=")+ additionalProperties)+"]");
     }
-
 }

--- a/src/us/kbase/narrativemethodstore/DropdownOptions.java
+++ b/src/us/kbase/narrativemethodstore/DropdownOptions.java
@@ -17,6 +17,29 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *
  *
  */
+
+
+/**
+ * <p>Original spec-file type: DropdownOptions</p>
+ * <pre>
+ * Defines a parameter field that allows users to select from a list of options. It will
+ * appear as a dropdown (a 'select' HTML element).
+ *
+ * Parameters:
+ *
+ *     options        - a list of maps with keys 'value' and 'display'; 'display' is the text
+ *                      presented to the user, and 'value' is what is passed from the element
+ *                      when it is submitted. See the DropDownOption type for the spec.
+ *
+ *     multiselection - If true, multiple selections are allowed from a single field, and
+ *                      the parameter will return a list, rather than a single value.
+ *                      This parameter is optional.
+ *                      Default = false
+ * </pre>
+ *
+ */
+
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({

--- a/src/us/kbase/narrativemethodstore/db/NarrativeMethodData.java
+++ b/src/us/kbase/narrativemethodstore/db/NarrativeMethodData.java
@@ -541,7 +541,8 @@ public class NarrativeMethodData {
 					String displayText = get(paramPath + "/dropdown_options/options/" + j, itemNode, "display").asText();
 					options.add(new DropdownOption().withValue(value).withDisplay(displayText));
 				}
-				ddOpt = new DropdownOptions().withOptions(options);
+				ddOpt = new DropdownOptions().withOptions(options)
+						.withMultiselection(jsonBooleanToRPC(optNode.get("multiselection"), 0L));
 			}
 			DynamicDropdownOptions dyddOpt = null;
 			if (paramNode.has("dynamic_dropdown_options")) {
@@ -868,7 +869,7 @@ public class NarrativeMethodData {
 		return node == null || node.isNull() ? defaultValue : node.asLong();
 	}
 
-	
+
 	private static Long jsonBooleanToRPC(JsonNode node) {
 		return node.asBoolean() ? 1L : 0L;
 	}

--- a/src/us/kbase/narrativemethodstore/db/test/NarrativeMethodDataTest.java
+++ b/src/us/kbase/narrativemethodstore/db/test/NarrativeMethodDataTest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jersey.repackaged.com.google.common.collect.ImmutableMap;
+import us.kbase.narrativemethodstore.DropdownOptions;
 import us.kbase.narrativemethodstore.DynamicDropdownOptions;
 import us.kbase.narrativemethodstore.MethodParameterGroup;
 import us.kbase.narrativemethodstore.db.FileLookup;
@@ -27,10 +28,10 @@ import us.kbase.narrativemethodstore.exceptions.NarrativeMethodStoreException;
 import us.kbase.narrativemethodstore.util.TextUtils;
 
 public class NarrativeMethodDataTest {
-    
+
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
-    
+
     @Test
     public void testGroupMultipleOk() throws Exception {
         NarrativeMethodData data = load(1);
@@ -52,7 +53,7 @@ public class NarrativeMethodDataTest {
     public void testGroupNoIdError() throws Exception {
         expectedEx.expect(NarrativeMethodStoreException.class);
         expectedEx.expectMessage("Can't find sub-node [id] within path [parameter-groups/0] in " +
-        		"spec.json");
+                "spec.json");
         load(2);
     }
 
@@ -60,7 +61,7 @@ public class NarrativeMethodDataTest {
     public void testGroupWrongParamError() throws Exception {
         expectedEx.expect(NarrativeMethodStoreException.class);
         expectedEx.expectMessage("Undeclared parameter [input_reads_label2] found within path " +
-        		"[parameter-groups/0/parameters]");
+                "[parameter-groups/0/parameters]");
         load(3);
     }
 
@@ -84,7 +85,7 @@ public class NarrativeMethodDataTest {
     public void testGroupOneMappingError() throws Exception {
         expectedEx.expect(NarrativeMethodStoreException.class);
         expectedEx.expectMessage("Unsupported mapping found for one-copy parameter-group " +
-        		"within path [parameter-groups/0]");
+                "within path [parameter-groups/0]");
         load(6);
     }
 
@@ -104,56 +105,71 @@ public class NarrativeMethodDataTest {
         Assert.assertEquals(1L, (long)group.getWithBorder());
     }
 
-	@Test
-	public void dynamicDropDown() throws Exception {
-		final NarrativeMethodData nmd = load(10);
-		final DynamicDropdownOptions ddo = nmd.getMethodSpec().getParameters().get(0)
-				.getDynamicDropdownOptions();
-		
-		assertThat("incorrect data source", ddo.getDataSource(), is("custom"));
-		assertThat("incorrect serv func", ddo.getServiceFunction(),
-				is("taxonomy_re_api.search_taxa"));
-		assertThat("incorrect template", ddo.getDescriptionTemplate(),
-				is("<div>{{scientific_name}}</div>"));
-		assertThat("incorrect multiselect", ddo.getMultiselection(), is(1L));
-		assertThat("incorrect select id", ddo.getSelectionId(), is("scientific_name"));
-		assertThat("incorrect params",
-				ddo.getServiceParams()
-						.asClassInstance(new TypeReference<List<Map<String, Object>>>() {}),
-				is(Arrays.asList(ImmutableMap.of(
-						"search_text", "prefix:{{dynamic_dropdown_input}}",
-						"ns", "ncbi_taxonomy"))));
-		assertThat("incorrect serv ver", ddo.getServiceVersion(), is("dev"));
-		assertThat("incorrect sub path", ddo.getPathToSelectionItems(),
-				is(Arrays.asList("result", "0", "results")));
-		assertThat("incorrect query empty", ddo.getQueryOnEmptyInput(), is(0L));
-		assertThat("incorrect result index", ddo.getResultArrayIndex(), is(3L));
-	}
-	
-	@Test
-	public void dynamicDropDownDefaults() throws Exception {
-		final NarrativeMethodData nmd = load(11);
-		final DynamicDropdownOptions ddo = nmd.getMethodSpec().getParameters().get(0)
-				.getDynamicDropdownOptions();
-		
-		assertThat("incorrect data source", ddo.getDataSource(), is("custom"));
-		assertThat("incorrect serv func", ddo.getServiceFunction(),
-				is("taxonomy_re_api.search_taxa"));
-		assertThat("incorrect template", ddo.getDescriptionTemplate(),
-				is("<div>{{scientific_name}}</div>"));
-		assertThat("incorrect multiselect", ddo.getMultiselection(), is(0L));
-		assertThat("incorrect select id", ddo.getSelectionId(), is("scientific_name"));
-		assertThat("incorrect params",
-				ddo.getServiceParams()
-						.asClassInstance(new TypeReference<List<Map<String, Object>>>() {}),
-				is(Arrays.asList(ImmutableMap.of(
-						"search_text", "prefix:{{dynamic_dropdown_input}}",
-						"ns", "ncbi_taxonomy"))));
-		assertThat("incorrect serv ver", ddo.getServiceVersion(), nullValue());
-		assertThat("incorrect sub path", ddo.getPathToSelectionItems(), nullValue());
-		assertThat("incorrect query empty", ddo.getQueryOnEmptyInput(), is(1L));
-		assertThat("incorrect result index", ddo.getResultArrayIndex(), is(0L));
-	}
+    @Test
+    public void standardDropDown() throws Exception {
+        final NarrativeMethodData nmd = load(8);
+        // 3 has multiselection disabled
+        // 6 has it enabled
+
+        final DropdownOptions ddoSingle = nmd.getMethodSpec().getParameters().get(3)
+                .getDropdownOptions();
+        assertThat("incorrect multiselect", ddoSingle.getMultiselection(), is(0L));
+
+        final DropdownOptions ddoMulti = nmd.getMethodSpec().getParameters().get(6)
+                .getDropdownOptions();
+        assertThat("incorrect multiselect", ddoMulti.getMultiselection(), is(1L));
+    }
+
+    @Test
+    public void dynamicDropDown() throws Exception {
+        final NarrativeMethodData nmd = load(10);
+        final DynamicDropdownOptions ddo = nmd.getMethodSpec().getParameters().get(0)
+                .getDynamicDropdownOptions();
+
+        assertThat("incorrect data source", ddo.getDataSource(), is("custom"));
+        assertThat("incorrect serv func", ddo.getServiceFunction(),
+                is("taxonomy_re_api.search_taxa"));
+        assertThat("incorrect template", ddo.getDescriptionTemplate(),
+                is("<div>{{scientific_name}}</div>"));
+        assertThat("incorrect multiselect", ddo.getMultiselection(), is(1L));
+        assertThat("incorrect select id", ddo.getSelectionId(), is("scientific_name"));
+        assertThat("incorrect params",
+                ddo.getServiceParams()
+                        .asClassInstance(new TypeReference<List<Map<String, Object>>>() {}),
+                is(Arrays.asList(ImmutableMap.of(
+                        "search_text", "prefix:{{dynamic_dropdown_input}}",
+                        "ns", "ncbi_taxonomy"))));
+        assertThat("incorrect serv ver", ddo.getServiceVersion(), is("dev"));
+        assertThat("incorrect sub path", ddo.getPathToSelectionItems(),
+                is(Arrays.asList("result", "0", "results")));
+        assertThat("incorrect query empty", ddo.getQueryOnEmptyInput(), is(0L));
+        assertThat("incorrect result index", ddo.getResultArrayIndex(), is(3L));
+    }
+
+    @Test
+    public void dynamicDropDownDefaults() throws Exception {
+        final NarrativeMethodData nmd = load(11);
+        final DynamicDropdownOptions ddo = nmd.getMethodSpec().getParameters().get(0)
+                .getDynamicDropdownOptions();
+
+        assertThat("incorrect data source", ddo.getDataSource(), is("custom"));
+        assertThat("incorrect serv func", ddo.getServiceFunction(),
+                is("taxonomy_re_api.search_taxa"));
+        assertThat("incorrect template", ddo.getDescriptionTemplate(),
+                is("<div>{{scientific_name}}</div>"));
+        assertThat("incorrect multiselect", ddo.getMultiselection(), is(0L));
+        assertThat("incorrect select id", ddo.getSelectionId(), is("scientific_name"));
+        assertThat("incorrect params",
+                ddo.getServiceParams()
+                        .asClassInstance(new TypeReference<List<Map<String, Object>>>() {}),
+                is(Arrays.asList(ImmutableMap.of(
+                        "search_text", "prefix:{{dynamic_dropdown_input}}",
+                        "ns", "ncbi_taxonomy"))));
+        assertThat("incorrect serv ver", ddo.getServiceVersion(), nullValue());
+        assertThat("incorrect sub path", ddo.getPathToSelectionItems(), nullValue());
+        assertThat("incorrect query empty", ddo.getQueryOnEmptyInput(), is(1L));
+        assertThat("incorrect result index", ddo.getResultArrayIndex(), is(0L));
+    }
 
     private static NarrativeMethodData load(int num) throws Exception {
         FileLookup fl = new FileLookup() {
@@ -170,10 +186,10 @@ public class NarrativeMethodDataTest {
                 loadTextResource("spec_" + num + ".properties"));
         Map<String,Object> display = YamlUtils.getDocumentAsYamlMap(
                 loadTextResource("display_" + num + ".properties"));
-        return new NarrativeMethodData("method_" + num, 
+        return new NarrativeMethodData("method_" + num,
                 spec, display, fl, null, null, null, null, null);
     }
-    
+
     private static String loadTextResource(String name) throws Exception {
         return TextUtils.text(NarrativeMethodDataTest.class.getResourceAsStream(name));
     }

--- a/src/us/kbase/narrativemethodstore/db/test/spec_8.properties
+++ b/src/us/kbase/narrativemethodstore/db/test/spec_8.properties
@@ -10,12 +10,12 @@
         "input": null,
         "output": null
     },
-    "parameters": [ 
+    "parameters": [
         {
             "id": "title",
             "default_values": [""],
             "optional": false,
-            "advanced": false, 
+            "advanced": false,
             "allow_multiple": false,
             "field_type": "text",
             "text_options": {
@@ -26,18 +26,18 @@
             "id": "description",
             "default_values": [""],
             "optional": false,
-            "advanced": false, 
+            "advanced": false,
             "allow_multiple": false,
             "field_type": "textarea",
             "text_options": {
                 "n_rows": 10
             }
         },
-        {   
+        {
             "id": "effort",
             "default_values": [""],
             "optional": true,
-            "advanced": false, 
+            "advanced": false,
             "allow_multiple": false,
             "field_type": "text",
             "validate_as": "int",
@@ -50,7 +50,7 @@
             "id": "severity",
             "default_values": [""],
             "optional": true,
-            "advanced": false, 
+            "advanced": false,
             "allow_multiple": false,
             "field_type": "dropdown",
             "dropdown_options": {
@@ -75,7 +75,7 @@
             "id": "time_started",
             "default_values": [""],
             "optional": false,
-            "advanced": false, 
+            "advanced": false,
             "allow_multiple": false,
             "field_type": "text",
             "text_options": {
@@ -85,22 +85,23 @@
             "id": "time_spent",
             "default_values": [""],
             "optional": false,
-            "advanced": false, 
+            "advanced": false,
             "allow_multiple": false,
             "field_type": "text",
             "validate_as": "float",
             "text_options": {
-                
+
             }
         },
         {
             "id": "task_type",
             "default_values": [""],
             "optional": false,
-            "advanced": false, 
+            "advanced": false,
             "allow_multiple": false,
             "field_type": "dropdown",
             "dropdown_options": {
+                "multiselection": true,
                 "options": [
                     {
                         "display": "Design",
@@ -129,7 +130,7 @@
             "id": "comments",
             "default_values": [""],
             "optional": true,
-            "advanced": false, 
+            "advanced": false,
             "allow_multiple": false,
             "field_type": "textarea",
             "text_options": {


### PR DESCRIPTION
Adding a "multiselection" parameter to allow dropdowns to have multi select enabled. The dynamic dropdown type already has a multi selection param so I used the same format for the dropdown type.

Note that full implementation requires modification of the narrative to implement the new spec; this will be done in a separate (obviously!) PR on the narrative repo.